### PR TITLE
handle nulls from libmtp in vendor/product name

### DIFF
--- a/src/simple-mtpfs-mtp-device.cpp
+++ b/src/simple-mtpfs-mtp-device.cpp
@@ -189,8 +189,10 @@ bool MTPDevice::listDevices()
     }
 
     for (int i = 0; i < raw_devices_cnt; ++i) {
-        std::cout << i + 1 << ": " << raw_devices[i].device_entry.vendor
-            << raw_devices[i].device_entry.product << "\n";
+        std::cout << i + 1 << ": " 
+            << (raw_devices[i].device_entry.vendor?raw_devices[i].device_entry.vendor:"Unknown vendor ")
+            << (raw_devices[i].device_entry.product?raw_devices[i].device_entry.product:"Unknown product") 
+            << "\n";
     }
     free(static_cast<void*>(raw_devices));
 


### PR DESCRIPTION
If libmtp does not recognize the USB id of a device, then it passes null for the vendor name and product name, which caused simple-mtp to segfault when listing devices.  
