### PR TITLE
fixedup badly formatted line in changelog and corrected dependency from ...

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ simple-mtpfs (0.2-1) unstable; urgency=low
 
   * Upgrade to v0.2
 
- -- Peter Hatina <phatina@gmail.com> Tue, 03 Dec 2013 21:51:20 +0100
+ -- Peter Hatina <phatina@gmail.com>  Tue, 03 Dec 2013 21:51:20 +0100
 
 simple-mtpfs (0.1-1) precise; urgency=low
 

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Vcs-Browser: https://github.com/phatina/simple-mtpfs
 
 Package: simple-mtpfs
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, fuse-utils
+Depends: ${shlibs:Depends}, ${misc:Depends}, fuse
 Provides: mtpfs
 Conflicts: mtpfs
 Description: Simple MTP fuse filesystem driver


### PR DESCRIPTION
...fuse-utils to just fuse - which works for ubuntu 13.10 and onwards atleast

works for me on ubuntu 13.10 :)
