### PR TITLE
Show correct folder timestamp

### DIFF
--- a/src/simple-mtpfs-fuse.cpp
+++ b/src/simple-mtpfs-fuse.cpp
@@ -433,6 +433,7 @@ int SMTPFileSystem::getattr(const char *path, struct stat *buf)
             buf->st_ino = dir->id();
             buf->st_mode = S_IFDIR | 0775;
             buf->st_nlink = 2;
+            buf->st_mtime = dir->modificationDate();
         } else if (content->file(tmp_file)) {
             const TypeFile *file = content->file(tmp_file);
             buf->st_ino = file->id();

--- a/src/simple-mtpfs-type-dir.cpp
+++ b/src/simple-mtpfs-type-dir.cpp
@@ -29,7 +29,8 @@ TypeDir::TypeDir():
     m_dirs(),
     m_files(),
     m_access_mutex(),
-    m_fetched(false)
+    m_fetched(false),
+    m_modif_date(0)
 {
 }
 
@@ -39,7 +40,8 @@ TypeDir::TypeDir(uint32_t id, uint32_t parent_id, uint32_t storage_id,
     m_dirs(),
     m_files(),
     m_access_mutex(),
-    m_fetched(false)
+    m_fetched(false),
+    m_modif_date(0)
 {
 }
 
@@ -49,7 +51,8 @@ TypeDir::TypeDir(LIBMTP_file_t *file):
     m_dirs(),
     m_files(),
     m_access_mutex(),
-    m_fetched(false)
+    m_fetched(false),
+    m_modif_date(file->modificationdate)
 {
 }
 
@@ -58,7 +61,8 @@ TypeDir::TypeDir(const TypeDir &copy):
     m_dirs(copy.m_dirs),
     m_files(copy.m_files),
     m_access_mutex(),
-    m_fetched(copy.m_fetched)
+    m_fetched(copy.m_fetched),
+    m_modif_date(copy.m_modif_date)
 {
 }
 

--- a/src/simple-mtpfs-type-dir.h
+++ b/src/simple-mtpfs-type-dir.h
@@ -54,6 +54,9 @@ public:
     std::set<TypeFile> files() const { return m_files; }
     bool isEmpty() const { return m_dirs.empty() && m_files.empty(); }
 
+	time_t modificationDate() const { return m_modif_date; }
+    void setModificationDate(time_t modif_date) { m_modif_date = modif_date; }
+	
     LIBMTP_folder_t *toLIBMTPFolder() const;
     TypeDir &operator =(const TypeDir &rhs);
     bool operator ==(const std::string &rhs) const { return TypeBasic::operator ==(rhs); }
@@ -66,6 +69,7 @@ private:
     std::set<TypeFile> m_files;
     mutable std::mutex m_access_mutex;
     bool m_fetched;
+    time_t m_modif_date;
 };
 
 #endif // SMTPFS_TYPE_DIR_H


### PR DESCRIPTION
Not sure why this wasn't implemented to start with. Anyway seems like libmtp gives us the creation date of folders, so we can use it for fuse - allows syncing programs that use timestamps to work.
