### PR TITLE
On partial read/write, keep reading.

### DIFF
--- a/src/simple-mtpfs-mtp-device.cpp
+++ b/src/simple-mtpfs-mtp-device.cpp
@@ -720,6 +720,7 @@ bool MTPDevice::listDevices(bool verbose, const std::string &dev_file)
             continue;
         std::cout << i + 1 << ": "
             << (raw_devices[i].device_entry.vendor ? raw_devices[i].device_entry.vendor : "Unknown vendor ")
+            << ", "
             << (raw_devices[i].device_entry.product ? raw_devices[i].device_entry.product : "Unknown product")
             << std::endl;
 #ifdef HAVE_LIBMTP_CHECK_CAPABILITY


### PR DESCRIPTION
This avoids rsync errors and avoids data loss with cp, due to failing to copy the last byte of 0.1953125% of files.

Unless direct_io is set, fuse expects a full read/write.

As a workaround for a device hanging bug, if the length of a file on a Samsung device is 500 bytes modulo 512 bytes, libmtp returns a partial read omitting the last byte which must be requested separately.

Fixes #85.

----

This fixes reading the files that fail. But attempting to write anything at all (whether it's a 5-byte file or a 500-byte file) currently seems to freeze the connection (with or without this patch), and reconnecting to the device is impossible without physically unplugging and re-plugging the cable. I'm guessing this is a device bug that can only be worked around in libmtp if at all, but haven't investigated.